### PR TITLE
feat(skill): add Hermes Agent notify integration

### DIFF
--- a/skills/agent-exec/SKILL.md
+++ b/skills/agent-exec/SKILL.md
@@ -23,6 +23,8 @@ Read `references/completion-events.md` when you need the `job.finished` payload 
 
 Read `references/openclaw.md` when a job completion should be routed back into an OpenClaw chat, user flow, or agent session.
 
+Read `references/hermes.md` when a job completion should notify a Hermes Agent session (e.g. deliver interpreted results to Telegram via `hermes notify`).
+
 ## Typical workflow
 
 1. Start the job with `agent-exec run`.
@@ -93,6 +95,7 @@ Read `references/openclaw.md` when the completion path should re-enter OpenClaw.
 Suggested patterns:
 
 - Return the event to the launching OpenClaw session: use `--notify-command` to forward the event to the original session or conversation id with `openclaw agent --deliver --reply-channel ... --session-id ... -m ...`.
+- Deliver interpreted results via Hermes Agent: use `--notify-command` with `hermes notify` to spin up a one-shot agent that reads the payload, inspects logs/files, and posts a human-readable summary to the origin chat. Read `references/hermes.md` for setup and examples.
 - Append to a file for a durable worker: use `--notify-file` when a separate process should handle retries, fanout, or slower downstream APIs.
 
 Operational reminders:

--- a/skills/agent-exec/references/hermes.md
+++ b/skills/agent-exec/references/hermes.md
@@ -1,0 +1,115 @@
+# Hermes Agent Integration
+
+Use this reference when `agent-exec` jobs must report completion back into a Hermes Agent session via `hermes notify`.
+
+## How it works
+
+1. `agent-exec run` starts a background job.
+2. On completion, `--notify-command` invokes `hermes notify`.
+3. `hermes notify` spins up a one-shot Hermes Agent that reads the notification payload, interprets it (may inspect files, logs, etc.), and delivers a human-readable response to the origin chat.
+
+This is different from posting a raw message to Telegram — the agent processes the result before responding.
+
+## Prerequisites
+
+- `hermes notify` is available at `~/.hermes/hermes-agent/venv/bin/hermes notify` (or on PATH).
+- A valid LLM provider must be reachable. Pass `--provider` explicitly to avoid credential resolution hangs in non-interactive environments.
+- The Telegram bot token (or other platform credentials) must be configured in `~/.hermes/.env`.
+
+## Pass session context via environment variables
+
+`hermes notify` resolves its delivery target from `HERMES_SESSION_*` environment variables. Inject them with `--env` at job creation time:
+
+```bash
+agent-exec run \
+  --env HERMES_SESSION_PLATFORM=telegram \
+  --env HERMES_SESSION_CHAT_ID=<chat_id> \
+  --env HERMES_SESSION_THREAD_ID=<thread_id> \
+  --notify-command 'hermes notify --provider <provider> -m "job $AGENT_EXEC_JOB_ID completed"' \
+  -- <command>
+```
+
+The `--env` variables are inherited by the notify-command process, so `hermes notify` picks them up automatically without needing `--platform`/`--chat-id`/`--thread-id` flags.
+
+## Recommended notify-command shape
+
+Keep the one-liner minimal. The agent will inspect logs and files on its own.
+
+```bash
+--notify-command 'hermes notify --provider <provider> -m "job_id=$AGENT_EXEC_JOB_ID event_path=$AGENT_EXEC_EVENT_PATH"'
+```
+
+For richer context, include the command description:
+
+```bash
+--notify-command 'hermes notify --provider <provider> -m "Build finished: job_id=$AGENT_EXEC_JOB_ID event_path=$AGENT_EXEC_EVENT_PATH"'
+```
+
+## Example: full launcher
+
+```bash
+HERMES=~/.hermes/hermes-agent/venv/bin/hermes
+
+agent-exec run \
+  --env HERMES_SESSION_PLATFORM=telegram \
+  --env HERMES_SESSION_CHAT_ID=971980613 \
+  --env HERMES_SESSION_THREAD_ID=27136 \
+  --notify-command "$HERMES notify --provider cliproxy -m 'Build done: job_id=\$AGENT_EXEC_JOB_ID event_path=\$AGENT_EXEC_EVENT_PATH'" \
+  -- make build
+```
+
+## Example: attach notification after launch
+
+```bash
+JOB=$(agent-exec run --snapshot-after 0 -- make test | jq -r .job_id)
+
+agent-exec notify set "$JOB" \
+  --command 'hermes notify --provider cliproxy -m "Tests finished: job_id=$AGENT_EXEC_JOB_ID event_path=$AGENT_EXEC_EVENT_PATH"'
+```
+
+Use this when session context is only available after the job starts.
+
+## Helper script
+
+For repeated use, create a wrapper script instead of inlining the full command:
+
+```bash
+#!/usr/bin/env bash
+# ~/.local/bin/hermes-notify-hook
+# Usage: agent-exec run --notify-command hermes-notify-hook -- <command>
+set -euo pipefail
+
+HERMES="${HERMES_BIN:-$HOME/.hermes/hermes-agent/venv/bin/hermes}"
+PROVIDER="${HERMES_NOTIFY_PROVIDER:-cliproxy}"
+
+exec "$HERMES" notify \
+  --provider "$PROVIDER" \
+  -m "job_id=$AGENT_EXEC_JOB_ID event_path=$AGENT_EXEC_EVENT_PATH"
+```
+
+Then launch jobs simply:
+
+```bash
+agent-exec run \
+  --env HERMES_SESSION_PLATFORM=telegram \
+  --env HERMES_SESSION_CHAT_ID=<chat_id> \
+  --env HERMES_SESSION_THREAD_ID=<thread_id> \
+  --notify-command hermes-notify-hook \
+  -- <command>
+```
+
+## Good patterns
+
+- Always pass `--provider` explicitly to avoid interactive credential prompts in headless contexts.
+- Use `--env` to inject `HERMES_SESSION_*` variables so notify-command inherits them automatically.
+- Include `job_id` and `event_path` in the message so the agent can inspect the completion event and job logs.
+- Keep the one-liner idempotent — duplicate delivery attempts should not cause side effects.
+- Use absolute paths for the `hermes` binary when PATH may differ inside the sink process.
+
+## Common mistakes
+
+- Omitting `--provider`, causing `hermes notify` to hang on interactive credential resolution.
+- Hardcoding `--thread-id` in `--notify-command` instead of using `HERMES_SESSION_THREAD_ID` via `--env`.
+- Sending the full event JSON as the message payload. The agent can read files — just pass `event_path`.
+- Using a model/provider that is slow or unreliable for one-shot callbacks. Prefer fast, cheap models.
+- Forgetting that `hermes notify` starts a full agent turn — it is not a simple HTTP POST. Budget ~10-30s for completion.

--- a/skills/agent-exec/scripts/hermes-notify-hook
+++ b/skills/agent-exec/scripts/hermes-notify-hook
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# hermes-notify-hook — agent-exec completion callback for Hermes Agent
+#
+# Usage:
+#   agent-exec run \
+#     --env HERMES_SESSION_PLATFORM=telegram \
+#     --env HERMES_SESSION_CHAT_ID=<chat_id> \
+#     --env HERMES_SESSION_THREAD_ID=<thread_id> \
+#     --notify-command hermes-notify-hook \
+#     -- <command>
+#
+# Environment variables (set by agent-exec):
+#   AGENT_EXEC_JOB_ID       — completed job id
+#   AGENT_EXEC_EVENT_PATH   — path to completion_event.json
+#   AGENT_EXEC_EVENT_TYPE   — always "job.finished"
+#
+# Environment variables (set by caller via --env):
+#   HERMES_SESSION_PLATFORM  — delivery platform (telegram, discord, slack, ...)
+#   HERMES_SESSION_CHAT_ID   — target chat id
+#   HERMES_SESSION_THREAD_ID — target thread/topic id (optional)
+#
+# Optional overrides:
+#   HERMES_BIN              — path to hermes binary (default: auto-detect)
+#   HERMES_NOTIFY_PROVIDER  — LLM provider for the callback agent (default: cliproxy)
+#   HERMES_NOTIFY_MODEL     — model override (optional)
+set -euo pipefail
+
+# Resolve hermes binary
+if [[ -n "${HERMES_BIN:-}" ]]; then
+  HERMES="$HERMES_BIN"
+elif command -v hermes &>/dev/null; then
+  HERMES="hermes"
+elif [[ -x "$HOME/.hermes/hermes-agent/venv/bin/hermes" ]]; then
+  HERMES="$HOME/.hermes/hermes-agent/venv/bin/hermes"
+else
+  echo "hermes-notify-hook: hermes binary not found" >&2
+  exit 1
+fi
+
+PROVIDER="${HERMES_NOTIFY_PROVIDER:-cliproxy}"
+MODEL_FLAG=""
+if [[ -n "${HERMES_NOTIFY_MODEL:-}" ]]; then
+  MODEL_FLAG="--model $HERMES_NOTIFY_MODEL"
+fi
+
+exec "$HERMES" notify \
+  --provider "$PROVIDER" \
+  $MODEL_FLAG \
+  -m "job_id=$AGENT_EXEC_JOB_ID event_path=$AGENT_EXEC_EVENT_PATH"


### PR DESCRIPTION
## Summary

Add documentation and a helper script for routing `agent-exec` job completions through Hermes Agent (`hermes notify`) to deliver interpreted results to messaging platforms.

## Changes

### New files
- **`skills/agent-exec/references/hermes.md`** — Reference doc covering:
  - How `hermes notify` works (spins up a one-shot agent, not a raw POST)
  - Passing session context via `--env HERMES_SESSION_*`
  - Recommended notify-command patterns
  - Common mistakes (provider omission hangs, hardcoded thread IDs, etc.)
- **`skills/agent-exec/scripts/hermes-notify-hook`** — Drop-in shell script for `--notify-command` that auto-detects the hermes binary and reads session env vars

### Modified files
- **`skills/agent-exec/SKILL.md`** — Added references to `hermes.md` in the rules section and completion events section